### PR TITLE
Fix 403 response on favicon.ico & robots.txt

### DIFF
--- a/overrides/src/Orchard.Web/Web.config
+++ b/overrides/src/Orchard.Web/Web.config
@@ -116,7 +116,7 @@
             <remove name="WarmupHttpModule" />
             <add name="WarmupHttpModule" type="Orchard.WarmupStarter.WarmupHttpModule, Orchard.WarmupStarter, Version=1.10, Culture=neutral" />
         </modules>
-        <handlers accessPolicy="Script">
+        <handlers accessPolicy="Script, Read">
             <!-- Clear all handlers, prevents executing code file extensions or returning any file contents. -->
             <clear />
             <add name="Favicon" path="favicon.ico" verb="*" modules="StaticFileModule" preCondition="integratedMode" resourceType="File" requireAccess="Read"/>


### PR DESCRIPTION
IIS is returning a 403 response because the access policy is missing "Read", which is what we're saying is required for `favicon.ico` & `robots.txt`.